### PR TITLE
Support deploy status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Slack Notify Step
-Posts wercker build status to a [Slack Channel](https://slack.com/).
+Posts wercker build/deploy status to a [Slack Channel](https://slack.com/).
 
 ![screenshot](https://raw.githubusercontent.com/wantedly/step-pretty-slack-notify/master/screenshot.png)
 
@@ -17,6 +17,15 @@ Options
 
 ```yml
 build:
+    after-steps:
+        - wantedly/pretty-slack-notify:
+            team: mycompany
+            token: $SLACK_API_TOKEN
+            channel: dev
+            username: cibot
+```
+```yml
+deploy:
     after-steps:
         - wantedly/pretty-slack-notify:
             team: mycompany

--- a/run.rb
+++ b/run.rb
@@ -27,8 +27,18 @@ git_commit = ENV["WERCKER_GIT_COMMIT"]
 git_branch = ENV["WERCKER_GIT_BRANCH"]
 started_by = ENV["WERCKER_STARTED_BY"]
 
-def message(app_name, app_url, build_url, git_commit, git_branch, started_by, status)
+deploy_url = ENV["WERCKER_DEPLOY_URL"]
+deploytarget_name = ENV["WERCKER_DEPLOYTARGET_NAME"]
+def deploy?
+  ENV["DEPLOY"] == "true"
+end
+
+def build_message(app_name, app_url, build_url, git_commit, git_branch, started_by, status)
   "[[#{app_name}](#{app_url})] [build(#{git_commit[0,8]})](#{build_url}) of #{git_branch} by #{started_by} #{status}"
+end
+
+def deploy_message(app_name, app_url, deploy_url, deploytarget_name, git_commit, git_branch, started_by, status)
+  "[[#{app_name}](#{app_url})] [deploy(#{git_commit[0,8]})](#{deploy_url}) of #{git_branch} to #{deploytarget_name} by #{started_by} #{status}"
 end
 
 def icon_url(status)
@@ -45,8 +55,12 @@ notifier = Slack::Notifier.new(
   channel: "##{channel}",
 )
 
+message = deploy? ?
+  deploy_message(app_name, app_url, deploy_url, deploytarget_name, git_commit, git_branch, started_by, ENV["WERCKER_RESULT"]) :
+  build_message(app_name, app_url, build_url, git_commit, git_branch, started_by, ENV["WERCKER_RESULT"])
+
 res = notifier.ping(
-  message(app_name, app_url, build_url, git_commit, git_branch, started_by, ENV["WERCKER_RESULT"]),
+  message,
   icon_url: icon_url(ENV["WERCKER_RESULT"]),
   username: username_with_status(username, ENV["WERCKER_RESULT"]),
 )

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,6 +1,6 @@
 name: pretty-slack-notify
-version: 0.1.0
-description: Posts wercker build status to a Slack channel
+version: 0.2.0
+description: Posts wercker build/deploy status to a Slack channel
 keywords:
   - notification
   - slack


### PR DESCRIPTION
こんにちは。

再度 レポジトリを作成し直し、もう一度同じブランチ名で PRお送りします！

通知のサンプルは下記のようになります。
### slack通知サンプル

```
・build の場合
[lazyppp/step-pretty-slack-notify] build(136d02b0) of master by lazyppp passed
・deploy の場合
[lazyppp/step-pretty-slack-notify] deploy(136d02b0) of master to production by lazyppp passed
```

テストは、 (https://app.wercker.com/#applications/5451c976ea87f6374f00301d/tab/details)
をworckerdirectoryにdeployして行いました。

問題なければ取り込んでいただけると嬉しいです。
よろしくお願い致します。
