### PR TITLE
Support notify on specific branches only

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ build:
     after-steps:
         - wantedly/pretty-slack-notify:
             webhook_url: $SLACK_WEBHOOK_URL
-            branches: master
+            branches: ^master$
 ```
 
 ## CHANGELOG

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Options
 
 * `channel`  - The Slack channel to override the default channel. (without #).
 * `username` - The name of your bot. (default `Wercker`)
+* `branches` - Specific branches to notify. (regular expression)
 
 ## EXAMPLE USAGE
 posts build notification
@@ -40,6 +41,16 @@ build:
             webhook_url: $SLACK_WEBHOOK_URL
             channel: dev
             username: cibot
+```
+
+notify on specific branches only
+
+```yml
+build:
+    after-steps:
+        - wantedly/pretty-slack-notify:
+            webhook_url: $SLACK_WEBHOOK_URL
+            branches: master
 ```
 
 ## CHANGELOG

--- a/run.rb
+++ b/run.rb
@@ -5,6 +5,7 @@ require "slack-notifier"
 webhook_url = ENV["WERCKER_PRETTY_SLACK_NOTIFY_WEBHOOK_URL"]
 channel     = ENV["WERCKER_PRETTY_SLACK_NOTIFY_CHANNEL"]
 username    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_USERNAME"]
+branches    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_BRANCHES"]
 
 abort "Please specify the your slack webhook url" unless webhook_url
 username = "Wercker"                              unless username
@@ -22,6 +23,12 @@ started_by = ENV["WERCKER_STARTED_BY"]
 
 deploy_url        = ENV["WERCKER_DEPLOY_URL"]
 deploytarget_name = ENV["WERCKER_DEPLOYTARGET_NAME"]
+
+if branches && Regexp.new(branches) !~ git_branch
+  puts "'#{git_branch}' branch did not match notify branches /#{branches}/"
+  puts "Skipped to notify"
+  exit
+end
 
 def deploy?
   ENV["DEPLOY"] == "true"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -16,3 +16,6 @@ properties:
   username:
     type: string
     required: false
+  branches:
+    type: string
+    required: false


### PR DESCRIPTION
## WHAT
### New Features

* Enable to notify on specific branches only

### Example Usage

```yml
build:
    after-steps:
        - wantedly/pretty-slack-notify:
            webhook_url: $SLACK_WEBHOOK_URL
            branches: ^master$
```

this matches `master`

```yml
build:
    after-steps:
        - wantedly/pretty-slack-notify:
            webhook_url: $SLACK_WEBHOOK_URL
            branches: ^(master|feature/.*)$
```

this matches `feature/hello`, `feature/world`...

## WHY
https://github.com/wantedly/step-pretty-slack-notify/issues/13