### PR TITLE
Use empty string for default value of environment variables

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -2,13 +2,13 @@
 
 require "slack-notifier"
 
-webhook_url = ENV["WERCKER_PRETTY_SLACK_NOTIFY_WEBHOOK_URL"]
-channel     = ENV["WERCKER_PRETTY_SLACK_NOTIFY_CHANNEL"]
-username    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_USERNAME"]
-branches    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_BRANCHES"]
-notify_on   = ENV["WERCKER_PRETTY_SLACK_NOTIFY_NOTIFY_ON"] || ""
-abort "Please specify the your slack webhook url" unless webhook_url
-username = "Wercker"                              unless username
+webhook_url = ENV["WERCKER_PRETTY_SLACK_NOTIFY_WEBHOOK_URL"] || ""
+channel     = ENV["WERCKER_PRETTY_SLACK_NOTIFY_CHANNEL"]     || ""
+username    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_USERNAME"]    || ""
+branches    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_BRANCHES"]    || ""
+notify_on   = ENV["WERCKER_PRETTY_SLACK_NOTIFY_NOTIFY_ON"]   || ""
+abort "Please specify the your slack webhook url" if webhook_url.empty?
+username = "Wercker"                              if username.empty?
 
 # See for more details about environment variables that we can use in our steps
 # http://devcenter.wercker.com/articles/steps/variables.html
@@ -24,7 +24,7 @@ started_by = ENV["WERCKER_STARTED_BY"]
 deploy_url        = ENV["WERCKER_DEPLOY_URL"]
 deploytarget_name = ENV["WERCKER_DEPLOYTARGET_NAME"]
 
-if branches && Regexp.new(branches) !~ git_branch
+if !branches.empty? && Regexp.new(branches) !~ git_branch
   puts "'#{git_branch}' branch did not match notify branches /#{branches}/"
   puts "Skipped to notify"
   exit
@@ -59,7 +59,7 @@ message = deploy? ?
   deploy_message(app_name, app_url, deploy_url, deploytarget_name, git_commit, git_branch, started_by, ENV["WERCKER_RESULT"]) :
   build_message(app_name, app_url, build_url, git_commit, git_branch, started_by, ENV["WERCKER_RESULT"])
 
-notifier.channel = '#' + channel if channel
+notifier.channel = '#' + channel unless channel.empty?
 
 if notify_on.empty? || notify_on == ENV["WERCKER_RESULT"]
   res = notifier.ping(


### PR DESCRIPTION
When using docker stack, it seems Wercker always sets empty string regardless of yaml configuration.

The build step log (It should be aborted with the message `Please specify ...`):
```
export WERCKER_STEP_ROOT="/pipeline/pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db"
export WERCKER_STEP_ID="pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db"
export WERCKER_STEP_OWNER="wantedly"
export WERCKER_STEP_NAME="pretty-slack-notify"
export WERCKER_REPORT_NUMBERS_FILE="/report/pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db/numbers.ini"
export WERCKER_REPORT_MESSAGE_FILE="/report/pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db/message.txt"
export WERCKER_REPORT_ARTIFACTS_DIR="/report/pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db/artifacts"
export WERCKER_PRETTY_SLACK_NOTIFY_USERNAME=""
export WERCKER_PRETTY_SLACK_NOTIFY_BRANCHES=""
export WERCKER_PRETTY_SLACK_NOTIFY_NOTIFY_ON=""
export WERCKER_PRETTY_SLACK_NOTIFY_WEBHOOK_URL=""
export WERCKER_PRETTY_SLACK_NOTIFY_CHANNEL=""
source "/pipeline/pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db/run.sh" < /dev/null
Ruby Version: ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
Ruby Path: /usr/local/bin/ruby
Install User: root

Installing slack-notifier...
Successfully installed slack-notifier-1.2.1
1 gem installed
/usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier/default_http_client.rb:27:in `request_obj': undefined method `request_uri' for #<URI::Generic > (NoMethodError)
	from /usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier/default_http_client.rb:21:in `call'
	from /usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier/default_http_client.rb:8:in `post'
	from /usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier.rb:26:in `ping'
	from /pipeline/pretty-slack-notify-b1281e11-e39c-4f83-b1f0-045384a495db/run.rb:65:in `<main>'
```