### PR TITLE
Use bundle install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1 (2016-11-22)
+Bugs Fixed:
+
+* Use `bundle install` to install dependencies [#37](https://github.com/wantedly/step-pretty-slack-notify/pull/37)
+
 ## 0.3.0 (2016-11-22)
 New Features:
 

--- a/run.sh
+++ b/run.sh
@@ -14,13 +14,22 @@ if which ruby > /dev/null 2>&1 ; then
   echo "Install User: ${CURRENT_USER}"
   echo ""
 
+  cd $WERCKER_STEP_ROOT
 
   if [ "${CURRENT_USER}" = "${RUBY_OWNER}" ]; then
+    if ! which bundler > /dev/null 2>&1 ; then
+      gem install bundler
+    fi
+
     echo "Installing slack-notifier..."
-         gem install slack-notifier -v 1.2.1 --no-ri --no-rdoc
+    bundle install
   else
+    if ! which bundler > /dev/null 2>&1 ; then
+      sudo gem install bundler
+    fi
+
     echo "Installing slack-notifier as root..."
-    sudo gem install slack-notifier -v 1.2.1 --no-ri --no-rdoc
+    sudo bundle install
   fi
 
   $WERCKER_STEP_ROOT/run.rb

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: pretty-slack-notify
-version: 0.3.0
+version: 0.3.1
 description: Posts wercker build/deploy status to a Slack channel
 keywords:
   - notification


### PR DESCRIPTION
## WHY

#36 does not work because correct version of slack-notifier is not installed.

```
Installing slack-notifier...
Successfully installed slack-notifier-1.2.1
1 gem installed
/usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier/link_formatter.rb:22:in `formatted': undefined method `gsub' for nil:NilClass (NoMethodError)
	from /usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier/link_formatter.rb:8:in `format'
	from /usr/local/bundle/gems/slack-notifier-1.2.1/lib/slack-notifier.rb:18:in `ping'
	from /pipeline/pretty-slack-notify-6cd1539f-6caf-4118-ab48-2fc8e5bdbf6c/run.rb:142:in `<main>'
```

Update of `run.sh` was missing.

## WHAT

Use Bundler to install dependencies.