### PR TITLE
Use `bundle exec` to execure script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.2 (2016-11-24)
+Bugs Fixed:
+
+* Use `bundle exec` to execure script [#38](https://github.com/wantedly/step-pretty-slack-notify/pull/38)
+
 ## 0.3.1 (2016-11-22)
 Bugs Fixed:
 

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,8 @@ if which ruby > /dev/null 2>&1 ; then
 
     echo "Installing slack-notifier..."
     bundle install
+
+    bundle exec $WERCKER_STEP_ROOT/run.rb
   else
     if ! which bundler > /dev/null 2>&1 ; then
       sudo gem install bundler
@@ -30,9 +32,9 @@ if which ruby > /dev/null 2>&1 ; then
 
     echo "Installing slack-notifier as root..."
     sudo bundle install
-  fi
 
-  $WERCKER_STEP_ROOT/run.rb
+    sudo bundle exec $WERCKER_STEP_ROOT/run.rb
+  fi
 else
   # Support Docker Box
   if which docker > /dev/null 2>&1 ; then

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: pretty-slack-notify
-version: 0.3.1
+version: 0.3.2
 description: Posts wercker build/deploy status to a Slack channel
 keywords:
   - notification


### PR DESCRIPTION
To resolve https://github.com/wantedly/step-pretty-slack-notify/pull/37#issuecomment-262361357

## WHY

`run.rb` does not use bundle-installed gems in some environments.

## WHAT

Wrap Ruby script with `bundle exec` to use bundle-installed gems.