### PR TITLE
Fix a bug when using sudo

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,7 @@ if which ruby > /dev/null 2>&1 ; then
     echo "Installing slack-notifier as root..."
     sudo bundle install
 
-    sudo bundle exec $WERCKER_STEP_ROOT/run.rb
+    sudo -E bundle exec $WERCKER_STEP_ROOT/run.rb
   fi
 else
   # Support Docker Box


### PR DESCRIPTION
## What does this PR do?
Add `-E` option to `sudo bundle exec $WERCKER_STEP_ROOT/run.rb` command.

## Motivation
To fix #39 

Environment variables are not passed when using sudo. 

## REF

```
$ sudo -h | grep -e "-E"
  -E, --preserve-env          preserve user environment when running command
```