### PR TITLE
Set default username correctly

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -108,13 +108,14 @@ end
 # These environment variables are required/optional for pretty-slack-notify step.
 webhook_url    = ENV["WERCKER_PRETTY_SLACK_NOTIFY_WEBHOOK_URL"]    || ""
 channel        = ENV["WERCKER_PRETTY_SLACK_NOTIFY_CHANNEL"]        || ""
-username       = ENV["WERCKER_PRETTY_SLACK_NOTIFY_USERNAME"]       || "Wercker"
+username       = ENV["WERCKER_PRETTY_SLACK_NOTIFY_USERNAME"]       || ""
 branches       = ENV["WERCKER_PRETTY_SLACK_NOTIFY_BRANCHES"]       || ""
 notify_on      = ENV["WERCKER_PRETTY_SLACK_NOTIFY_NOTIFY_ON"]      || ""
 passed_message = ENV["WERCKER_PRETTY_SLACK_NOTIFY_PASSED_MESSAGE"] || ""
 failed_message = ENV["WERCKER_PRETTY_SLACK_NOTIFY_FAILED_MESSAGE"] || ""
 icon_url       = "https://secure.gravatar.com/avatar/a08fc43441db4c2df2cef96e0cc8c045?s=140"
 
+username = "Wercker" if username.empty?
 abort "Please specify the your slack webhook url" if webhook_url.empty?
 
 build = Build.new


### PR DESCRIPTION
## What does this PR do?
Fix the bug which set empty username as default.
This was produced by me when I refactored this 😭 

![](https://cloud.githubusercontent.com/assets/7517/20806922/ab927942-b7b1-11e6-8dc7-64574d2c5d67.png)

(this image is from this comment: https://github.com/wantedly/step-pretty-slack-notify/issues/40#issuecomment-264254421)

As you can see above, wercker sets `""` to `WERCKER_PRETTY_SLACK_NOTIFY_USERNAME` if `username` option is not specified. Then default username is set to `""`.

```ruby
username       = ENV["WERCKER_PRETTY_SLACK_NOTIFY_USERNAME"]       || "Wercker"
# => ""
```

## Motivation
To fix [Username does not default to Wercker · Issue #40 · wantedly/step-pretty-slack-notify](https://github.com/wantedly/step-pretty-slack-notify/issues/40#issuecomment-264084350)