### PR TITLE
Prepare for v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.4 (2016-12-02)
+Bugs Fixed:
+
+* Set default username correctly [#43](https://github.com/wantedly/step-pretty-slack-notify/pull/43)
+
 ## 0.3.3 (2016-12-01)
 Bugs Fixed:
 

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: pretty-slack-notify
-version: 0.3.3
+version: 0.3.4
 description: Posts wercker build/deploy status to a Slack channel
 keywords:
   - notification


### PR DESCRIPTION
## WHY

To release new version including the fix #43 .

## WHAT

Prepare to release v0.3.4.

@koudaiii After merging this, please click `deploy` and release new version if you can.