### PR TITLE
Fix git_commit_url for bitbucket

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -43,7 +43,7 @@ class Build
     when "github.com" then
       "https://#{@git_domain}/#{@git_owner}/#{@git_repo}/commit/#{@git_commit}"
     when "bitbucket.org" then
-      "https://#{@git_domain}/#{@git_owner}/#{@git_repo}/commit/#{@git_commit}"
+      "https://#{@git_domain}/#{@git_owner}/#{@git_repo}/commits/#{@git_commit}"
     else
       nil
     end


### PR DESCRIPTION
Unlike github, bitbucket uses `commits` for the naming of commit url pages.

ex) https://bitbucket.org/bennettjessy/samples/commits/8f9721c36b13ec4fa70890b2bfc52aa6b24f2d11